### PR TITLE
Uppercased and clickable names

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,9 +116,15 @@ class App extends React.Component {
     let typesList = "";
     if (this.state.pokemon != null) {
       typesList = this.state.pokemon.types.map(type => {
+        let url_prefix = "https://bulbapedia.bulbagarden.net/wiki/";
+        let url_suffix = "_(type)";
         let name_fixed =
           type.type.name[0].toUpperCase() + type.type.name.slice(1);
-        return <div className="listItem">{name_fixed}</div>;
+        return (
+          <a href={url_prefix + name_fixed + url_suffix}>
+            <div className="listItem">{name_fixed}</div>
+          </a>
+        );
       });
     }
 

--- a/src/App.js
+++ b/src/App.js
@@ -99,11 +99,17 @@ class App extends React.Component {
     let abilitiesList = "";
     if (this.state.pokemon != null) {
       abilitiesList = this.state.pokemon.abilities.map(ability => {
+        let url_prefix = "https://bulbapedia.bulbagarden.net/wiki/";
+        let url_suffix = "_(Ability)";
         let name_fixed = ability.ability.name
           .split("-")
           .map(part => part[0].toUpperCase() + part.slice(1))
           .join(" ");
-        return <div className="listItem">{name_fixed}</div>;
+        return (
+          <a href={url_prefix + name_fixed.replace(" ", "_") + url_suffix}>
+            <div className="listItem">{name_fixed}</div>
+          </a>
+        );
       });
     }
 

--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,6 @@ class SearchForm extends React.Component {
   test(e) {
     e.preventDefault();
     let pokemonName = e.target.pokemonName.value;
-    console.log(pokemonName);
     this.props.onChange(pokemonName);
   }
 
@@ -47,11 +46,16 @@ class PokemonName extends React.Component {
     if (this.props.pokemon == null) {
       return null;
     } else {
+      let url_prefix = "https://bulbapedia.bulbagarden.net/wiki/";
+      let url_suffix = "_(Pokémon)";
+      let name_uppercased =
+        this.props.pokemon.name[0].toUpperCase() +
+        this.props.pokemon.name.slice(1);
       return (
         <div>
-          nº {this.props.pokemon.id} -{" "}
-          {this.props.pokemon.name[0].toUpperCase() +
-            this.props.pokemon.name.slice(1)}
+          <a href={url_prefix + name_uppercased + url_suffix}>
+            nº {this.props.pokemon.id} - {name_uppercased}
+          </a>
         </div>
       );
     }
@@ -84,14 +88,9 @@ class App extends React.Component {
 
     P.getPokemonByName(pokemonName)
       .then(function(response) {
-        console.log(response);
         self.setState({ pokemon: response });
-
-        console.log(response.abilities);
-        console.log(response.abilities[0].ability.name);
       })
       .catch(function(error) {
-        console.log(error);
         self.setState({ pokemon: null });
       });
   }
@@ -99,16 +98,22 @@ class App extends React.Component {
   render() {
     let abilitiesList = "";
     if (this.state.pokemon != null) {
-      abilitiesList = this.state.pokemon.abilities.map(ability => (
-        <div className="listItem">{ability.ability.name}</div>
-      ));
+      abilitiesList = this.state.pokemon.abilities.map(ability => {
+        let name_fixed = ability.ability.name
+          .split("-")
+          .map(part => part[0].toUpperCase() + part.slice(1))
+          .join(" ");
+        return <div className="listItem">{name_fixed}</div>;
+      });
     }
 
     let typesList = "";
     if (this.state.pokemon != null) {
-      typesList = this.state.pokemon.types.map(type => (
-        <div className="listItem">{type.type.name}</div>
-      ));
+      typesList = this.state.pokemon.types.map(type => {
+        let name_fixed =
+          type.type.name[0].toUpperCase() + type.type.name.slice(1);
+        return <div className="listItem">{name_fixed}</div>;
+      });
     }
 
     return (


### PR DESCRIPTION
Pokémon name, abilities and types are now "uppercased" (first letter of each name is uppercase, and also replaced dashes with spaces) and clickable, redirecting to the related Bulbapedia page.